### PR TITLE
Expand input types

### DIFF
--- a/src/Include.ts
+++ b/src/Include.ts
@@ -1,10 +1,10 @@
-import type { Input } from './Input';
+import type { IncludeInput } from './Input';
 import type { Rule } from './Rule';
 
 type LocalInclude = {
 	component?: never;
 	file?: never;
-	inputs?: Record<string, Input>;
+	inputs?: Record<string, IncludeInput>;
 	local: string;
 	project?: never;
 	ref?: never;
@@ -15,7 +15,7 @@ type LocalInclude = {
 type ComponentInclude = {
 	component: string;
 	file?: never;
-	inputs?: Record<string, Input>;
+	inputs?: Record<string, IncludeInput>;
 	local?: never;
 	project?: never;
 	ref?: never;
@@ -26,7 +26,7 @@ type ComponentInclude = {
 type ProjectInclude = {
 	component?: never;
 	file: string | string[];
-	inputs?: Record<string, Input>;
+	inputs?: Record<string, IncludeInput>;
 	local?: never;
 	project: string;
 	ref?: string;
@@ -37,7 +37,7 @@ type ProjectInclude = {
 type RemoteInclude = {
 	component?: never;
 	file?: never;
-	inputs?: Record<string, Input>;
+	inputs?: Record<string, IncludeInput>;
 	local?: never;
 	project?: never;
 	ref?: never;
@@ -48,7 +48,7 @@ type RemoteInclude = {
 type TemplateInclude = {
 	component?: never;
 	file?: never;
-	inputs?: Record<string, Input>;
+	inputs?: Record<string, IncludeInput>;
 	local?: never;
 	project?: never;
 	ref?: never;

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,14 +1,15 @@
-export type Input =
+export type IncludeInput =
 	| string
 	| number
 	| boolean
 	| string[]
 	| Record<string, any>[]
-	| (string | Record<string, string | string[]>)[] // this is not documented but it works
-	| {
-			default?: string | string[] | Record<string, string | string[]>;
-			description?: string;
-			options?: string[];
-			regex?: string;
-			type?: 'array' | 'string' | 'number' | 'boolean';
-	  };
+	| (string | Record<string, string | string[]>)[]; // this is not documented but it works
+
+export type ComponentInputSpec = {
+	default?: string | string[] | Record<string, string | string[]>;
+	description?: string;
+	options?: string[];
+	regex?: string;
+	type?: 'array' | 'string' | 'number' | 'boolean';
+};

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,9 +1,9 @@
 export type Input =
 	| string
-    | number
-    | boolean
-    | string[]
-    | Record<string,any>[]
+	| number
+	| boolean
+	| string[]
+	| Record<string, any>[]
 	| (string | Record<string, string | string[]>)[] // this is not documented but it works
 	| {
 			default?: string | string[] | Record<string, string | string[]>;

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,5 +1,9 @@
 export type Input =
 	| string
+    | number
+    | boolean
+    | string[]
+    | Record<string,any>[]
 	| (string | Record<string, string | string[]>)[] // this is not documented but it works
 	| {
 			default?: string | string[] | Record<string, string | string[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { stringify } from 'yaml';
 import { referenceTag } from './referenceTag';
 import type { PipelineRef } from './Include';
-import type { Input } from './Input';
+import type { ComponentInputSpec } from './Input';
 import type { Job, JobDefaults } from './Job';
 import type { GitlabCICDVariables } from './Variables';
 import type { Workflow } from './Workflow';
@@ -12,7 +12,7 @@ export { type JobNeed } from './Need';
 export { ReferenceTag } from './referenceTag';
 
 export type YAMLHeader = {
-	spec?: { inputs?: Record<string, Input> };
+	spec?: { inputs?: Record<string, ComponentInputSpec> };
 };
 
 export type GlobalKeywords = {


### PR DESCRIPTION
Expands input types to support passing in values to CI components inputs with array / integer / boolean input types

https://docs.gitlab.com/ee/ci/yaml/inputs.html#input-types 

