### PR TITLE
Allow pipelines to not include jobs or global keywords

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,13 @@ export function toYAML(pipeline: Pipeline) {
 		result += '---\n\n';
 	}
 
-	result += stringify(pipeline.globalKeywords, stringifyOptions);
-	result += stringify(pipeline.jobs, stringifyOptions);
+	if (Object.keys(pipeline.globalKeywords).length) {
+		result += stringify(pipeline.globalKeywords, stringifyOptions);
+	}
+
+	if (Object.keys(pipeline.jobs).length) {
+		result += stringify(pipeline.jobs, stringifyOptions);
+	}
 
 	return result;
 }

--- a/test/minimalPipeline.ts
+++ b/test/minimalPipeline.ts
@@ -1,0 +1,20 @@
+import { equal } from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { toYAML, type Pipeline } from '../dist/index';
+
+test('minimal pipeline', () => {
+	const minimalPipeline: Pipeline = {
+		globalKeywords: {
+			workflow: {
+				name: 'Minimal Pipeline',
+			},
+		},
+		jobs: {},
+	};
+
+	equal(
+		toYAML(minimalPipeline),
+		readFileSync('./test/minimalPipeline.yaml', 'utf-8'),
+	);
+});

--- a/test/minimalPipeline.yaml
+++ b/test/minimalPipeline.yaml
@@ -1,0 +1,2 @@
+workflow:
+  name: Minimal Pipeline


### PR DESCRIPTION
There are use-cases where we don't want pipelines to have jobs such as when an imported CI component is expected to provide all of the jobs.

Current behavior is the library will render an empty object `{}` which is invalid YAML and breaks gitlab pipelines.

This change allows minimal pipelines to exist without jobs or global keywords