### PR TITLE
Bugfix: allow Rule[] in PipelineRef

### DIFF
--- a/src/Include.ts
+++ b/src/Include.ts
@@ -57,7 +57,7 @@ type TemplateInclude = {
 };
 
 export type PipelineRef = {
-	rules?: Rule[];
+	rules?: Pick<Rule, 'if' | 'exists' | 'changes'>[];
 } & (
 	| LocalInclude
 	| ComponentInclude

--- a/src/Include.ts
+++ b/src/Include.ts
@@ -57,7 +57,7 @@ type TemplateInclude = {
 };
 
 export type PipelineRef = {
-	rules?: Pick<Rule, 'if' | 'exists' | 'changes'>;
+	rules?: Rule[];
 } & (
 	| LocalInclude
 	| ComponentInclude

--- a/test/pipelineWithInclude.ts
+++ b/test/pipelineWithInclude.ts
@@ -16,24 +16,21 @@ test('pipeline with include', () => {
 					ref: 'main',
 					file: '/ci_library/file.yml',
 				},
-                {
+				{
 					project: 'somewhere',
 					ref: 'main',
 					file: '/ci_library/file.yml',
-                    rules: [
-                        {
-                            if: 'foo == foo',
-                            when: 'never'
-                        },
-                        {
-                            if: 'bar == bar',
-                            when: 'on_success',
-                            changes: [
-                                "foo/*",
-                                "bar/*"
-                            ]
-                        }
-                    ]
+					rules: [
+						{
+							if: 'foo == foo',
+							when: 'never',
+						},
+						{
+							if: 'bar == bar',
+							when: 'on_success',
+							changes: ['foo/*', 'bar/*'],
+						},
+					],
 				},
 			],
 		},

--- a/test/pipelineWithInclude.ts
+++ b/test/pipelineWithInclude.ts
@@ -23,11 +23,9 @@ test('pipeline with include', () => {
 					rules: [
 						{
 							if: 'foo == foo',
-							when: 'never',
 						},
 						{
 							if: 'bar == bar',
-							when: 'on_success',
 							changes: ['foo/*', 'bar/*'],
 						},
 					],

--- a/test/pipelineWithInclude.ts
+++ b/test/pipelineWithInclude.ts
@@ -16,6 +16,25 @@ test('pipeline with include', () => {
 					ref: 'main',
 					file: '/ci_library/file.yml',
 				},
+                {
+					project: 'somewhere',
+					ref: 'main',
+					file: '/ci_library/file.yml',
+                    rules: [
+                        {
+                            if: 'foo == foo',
+                            when: 'never'
+                        },
+                        {
+                            if: 'bar == bar',
+                            when: 'on_success',
+                            changes: [
+                                "foo/*",
+                                "bar/*"
+                            ]
+                        }
+                    ]
+				},
 			],
 		},
 		jobs: {

--- a/test/pipelineWithInclude.yaml
+++ b/test/pipelineWithInclude.yaml
@@ -7,6 +7,17 @@ include:
   - project: somewhere
     ref: main
     file: /ci_library/file.yml
+  - project: somewhere
+    ref: main
+    file: /ci_library/file.yml
+    rules:
+      - if: foo == foo
+        when: never
+      - if: bar == bar
+        when: on_success
+        changes:
+          - foo/*
+          - bar/*
 job1:
   stage: test
   script:

--- a/test/pipelineWithInclude.yaml
+++ b/test/pipelineWithInclude.yaml
@@ -12,9 +12,7 @@ include:
     file: /ci_library/file.yml
     rules:
       - if: foo == foo
-        when: never
       - if: bar == bar
-        when: on_success
         changes:
           - foo/*
           - bar/*


### PR DESCRIPTION
Removes the typescript error:

```
Include.d.ts(54, 5): The expected type comes from property 'rules' which is declared here on type 'PipelineRef'

(property) rules?: Pick<Rule, "if" | "exists" | "changes"> | undefined
```

when entering valid rules into a `PipelineRef` include

```
const config: PipelineRef = {
  component: ...
  inputs: {
			...
		}
  rules: [
	{
		if: `$CI_PIPELINE_SOURCE == "push"`,
	},
]
```


