### PR TITLE
Add sideEffects: false to package.json

### DIFF
--- a/.changeset/brave-eagles-dream.md
+++ b/.changeset/brave-eagles-dream.md
@@ -1,0 +1,5 @@
+---
+"gitlab-dynamic-pipelines": patch
+---
+
+Add sideEffects: false to package.json to enable better tree-shaking in bundlers

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "git+https://github.com/onlywei/gitlab-dynamic-pipelines.git"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This enables better tree-shaking in bundlers like webpack and rollup. Since
this library only exports pure functions, types, and classes without any
module-level side effects, marking it as side-effect-free allows bundlers to
safely remove unused exports, reducing bundle sizes for consumers.