### PR TITLE
Typecheck test files without adding test libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "prepublishOnly": "pnpm build",
-    "test": "node --test"
+    "test": "tsc -p tsconfig.test.json && node --test"
   },
   "dependencies": {
     "yaml": "^2.8.2"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
The test files were not being type-checked because `tsconfig.json` only included `src/**/*.ts`. This meant invalid properties on Pipeline objects would silently pass through to YAML output.

Add `tsconfig.test.json` that extends the base config but includes test files, and update the test script to run `tsc` before `node --test`. This ensures TypeScript's excess property checking catches invalid keys.

Fixes #21