### PR TITLE
Allow no trigger branch

### DIFF
--- a/.changeset/funky-masks-arrive.md
+++ b/.changeset/funky-masks-arrive.md
@@ -1,0 +1,5 @@
+---
+"gitlab-dynamic-pipelines": patch
+---
+
+Allow trigger branch to be optional

--- a/src/Job.ts
+++ b/src/Job.ts
@@ -119,7 +119,7 @@ type TriggerConfig = (
     }
   | {
       project: string;
-      branch: string;
+      branch?: string;
     }
 ) & {
   forward?: { yaml_variables?: boolean; pipeline_variables?: boolean };


### PR DESCRIPTION
This merge request makes the `branch` attribute in the `TriggerConfig` optional. The GitLab CI/CD documentation states the following:

> By default, the multi-project pipeline triggers for the default branch. Use `trigger:branch` to specify a different branch.

Reference: https://docs.gitlab.com/ci/yaml/#triggerproject